### PR TITLE
Update SolutionStacks for Amazon Linux 2

### DIFF
--- a/server/app/models/Platform/resolvers/solutionStacks.js
+++ b/server/app/models/Platform/resolvers/solutionStacks.js
@@ -13,7 +13,7 @@ export default resolver({
     const beanstalk = await app.beanstalk()
     const result = await beanstalk.listAvailableSolutionStacks().promise()
     return result.SolutionStacks.filter(name =>
-      name.includes(`running ${platform.beanstalkSolutionStackName}`)
+      name.includes(`running ${platform.beanstalkSolutionStackName} `)
     )
   }
 })


### PR DESCRIPTION
Amazon changed how they name the solution stacks which meant the previous code would put you on a deprecated Node platform.

This proposed change will put you on `64bit Amazon Linux 2` and then in line 5 of [getSolutionStackName.js](https://github.com/nicolaslopezj/waveshosting/blob/82054a875c88214fff850172f579c95b06145802/server/app/resolvers/Environment/createEnvironment/getSolutionStackName.js) you're grabbing the first item from this array which means the app will use the latest one for Node 14 (currently `64bit Amazon Linux 2 v5.4.5 running Node.js 14`).

I looked at your code for a while and would rather do something like this to be more deterministic for Meteor specifically but I'm honestly not really sure how to do it.

```js
export const getNodeVersion = (directory) => {
  let star = fs.readFileSync(`${directory}/bundle/star.json`).toString();
  star = JSON.parse(star);

  if (star.npmVersion) {
    return {
      nodeVersion: star.nodeVersion,
      npmVersion: star.npmVersion
    };
  }
}

 // from cli
const buildDir = getBuildDir();
const buildArchivePath = await buildApp({
    build: customBuildScript || app.platformId,
    buildDir
});

const { nodeVersion } = getNodeVersion(buildArchivePath);
const majorNodeVersion = nodeVersion.split('.')[0];

 async resolve(platform, {appId}, viewer) {
    const app = await Apps.findOne(appId)
    const beanstalk = await app.beanstalk()
    const result = await beanstalk.listAvailableSolutionStacks().promise()
    return result.SolutionStacks.filter(name =>
      name.includes(`running ${platform.beanstalkSolutionStackName} ${majorNodeVersion}`)
    )
  }
```

Another alternative would be to allow the user to pick the major node version in a dropdown after they select the platform when they are creating the app but that kind of takes away from the feeling of "it just works" especially when we should already know the major node version.